### PR TITLE
Send email_received_unacceptable signal when an attachment is too large

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,6 +92,10 @@ The flow through the app is very simple:
    you require - e.g. DKIM / SPF info, if your provider passes that
    along).
 
+If an email is unacceptable in some way (e.g. an attachment is too large),
+then the ``email_received_unacceptable`` signal is fired instead. This signal
+has an argument ``exception`` describing the problem.
+
 Installation
 ------------
 
@@ -186,7 +190,7 @@ Things it will do:
 -  Parse HTTP requests into EmailMultiAlternatives objects
 -  Pluggable backends (SendGrid only on launch)
 -  Handle character encodings properly
--  Handle attachments
+-  Handle attachments, including if they are too large
 
 Things it (probably) won't do:
 

--- a/django_inbound_email/backends/__init__.py
+++ b/django_inbound_email/backends/__init__.py
@@ -9,6 +9,16 @@ class RequestParseError(Exception):
     pass
 
 
+class AttachmentTooLargeError(Exception):
+    """Error raised when an attachment is too large."""
+
+    def __init__(self, email, filename, size):
+        super(AttachmentTooLargeError, self)
+        self.email = email
+        self.filename = filename
+        self.size = size
+
+
 def get_backend_class():
     """Return reference to the configured backed class."""
     # this will (intentionally) blow up if the setting does not exist
@@ -24,6 +34,7 @@ def get_backend_instance():
     """Dynamically create an instance of the configured backend class."""
     backend = get_backend_class()
     return backend()
+
 
 class RequestParser():
     """Abstract base class, to be implemented by service-specific classes."""

--- a/django_inbound_email/backends/sendgrid.py
+++ b/django_inbound_email/backends/sendgrid.py
@@ -7,7 +7,12 @@ from django.http import HttpRequest
 from django.utils.datastructures import MultiValueDictKeyError
 from django.utils.encoding import smart_text
 
-from django_inbound_email.backends import RequestParser, RequestParseError
+from django_inbound_email.backends import (
+    RequestParser,
+    RequestParseError,
+    AttachmentTooLargeError,
+)
+
 
 logger = logging.getLogger(__name__)
 
@@ -92,6 +97,11 @@ class SendGridRequestParser(RequestParser):
                     u"File attachment %s is too large to process (%sB)",
                     f.name,
                     f.size
+                )
+                raise AttachmentTooLargeError(
+                    email=email,
+                    filename=f.name,
+                    size=f.size
                 )
             else:
                 email.attach(n, f.read(), f.content_type)

--- a/django_inbound_email/signals.py
+++ b/django_inbound_email/signals.py
@@ -1,6 +1,12 @@
 # Signals definitions for django-inbound-email
 from django.dispatch import Signal
 
+
 # this is fired when a new email has been successfully parsed
 # from the inbound view function.
 email_received = Signal(providing_args=['email', 'request'])
+
+
+# this is fired when a new email has failed validation
+email_received_unacceptable = Signal(
+    providing_args=['email', 'request', 'exception'])


### PR DESCRIPTION
Raise AttachmentTooLargeError (an Exception) when at least one attachment
is too large and send it out via the new signal email_received_unacceptable.

Client applications can choose to listen for this signal (or not).
