### PR TITLE
Hotfix/handle Commas in name part of mailbox address

### DIFF
--- a/django_inbound_email/backends/mandrill.py
+++ b/django_inbound_email/backends/mandrill.py
@@ -1,4 +1,4 @@
-#encoding=utf-8
+# encoding=utf-8
 
 import re
 import json
@@ -65,16 +65,16 @@ class MandrillRequestParser(RequestParser):
            from the array [["address@example.com", "Name"]]
         """
         for address, name in array:
-            if name is None:
+            if not name:
                 yield address
             else:
-                yield "%s <%s>" % (name, address)
+                yield "\"%s\" <%s>" % (name, address)
 
     def _get_sender(self, from_email, from_name=None):
         if not from_name:
             return from_email
         else:
-            return "%s <%s>" % (from_name, from_email)
+            return "\"%s\" <%s>" % (from_name, from_email)
 
     def parse(self, request):
         """Parse incoming request and return an email instance.

--- a/django_inbound_email/views.py
+++ b/django_inbound_email/views.py
@@ -2,17 +2,18 @@
 # -*- coding: utf-8 -*-
 import logging
 
-from django.core.mail import EmailMultiAlternatives
 from django.conf import settings
+from django.core.mail import EmailMultiAlternatives
+from django.http import HttpResponse
 from django.views.decorators.csrf import csrf_exempt
-from django.views.decorators.http import require_http_methods, HttpResponse
+from django.views.decorators.http import require_http_methods
 
-from django_inbound_email.signals import email_received, email_received_unacceptable
 from django_inbound_email.backends import get_backend_instance
 from django_inbound_email.errors import (
     RequestParseError,
     AttachmentTooLargeError,
 )
+from django_inbound_email.signals import email_received, email_received_unacceptable
 
 
 logger = logging.getLogger(__name__)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = django165_py27, django171_py27
+envlist = django165_py27, django171_py27, django1812_py27, django197_py27
 
 [testenv]
 commands=python manage.py test test_app django_inbound_email
@@ -16,3 +16,18 @@ deps =
 basepython = python2.7
 deps =
     Django==1.7.1
+
+
+[testenv:django1812_py27]
+basepython = python2.7
+deps =
+    Django==1.8.12
+
+
+[testenv:django197_py27]
+basepython = python2.7
+deps =
+    Django==1.9.7
+
+
+

--- a/tox.ini
+++ b/tox.ini
@@ -1,21 +1,21 @@
 [tox]
-envlist = django165_py27, django171_py27, django1812_py27, django197_py27
+envlist = django1611_py27, django1711_py27, django1812_py27, django197_py27
 
 [testenv]
 commands=python manage.py test test_app django_inbound_email
 
 
-[testenv:django165_py27]
+[testenv:django1611_py27]
 basepython = python2.7
 deps =
-    Django==1.6.5
+    Django==1.6.11
     South==1.0.1
 
 
-[testenv:django171_py27]
+[testenv:django1711_py27]
 basepython = python2.7
 deps =
-    Django==1.7.1
+    Django==1.7.11
 
 
 [testenv:django1812_py27]


### PR DESCRIPTION
This changeset updates the Mandrill backend to better format the name in mailbox strings.
## Background

When extracting to and from addresses from the Mandrill webhook payload, we were turning two strings into one. (Issue #20)

eg "sam.seaborne@whitehouse.gov" and "Sam Seaborne"
into "`Sam Seaborne <sam.seaborne@whitehouse.gov>`"

However, this isn't strictly correct, due to the space in the name (see https://en.wikipedia.org/wiki/Email_address#Local_part for a quick ref, or dive into the RFC - https://www.tools.ietf.org/html/rfc5322.html#section-3.4.1).

Quoting it should make parsing it more reliable, though - in whatever client code is using django-inbound-email and the Mandrill backend - Python's `email.utils.parseaddr` seems to cope fine:

```
>>> parseaddr('Jed Bartlet <jed@whitehouse.gov>')
('Jed Bartlet', 'jed@whitehouse.gov')
```

However, when the name has a comma in it,  the resulting mailbox string produced by the Mandrill backend was NOT parseable, because it was invalid.

ie "sam.seaborne@whitehouse.gov" and "Seaborne, Sam"
into "`Seaborne, Sam <sam.seaborne@whitehouse.gov>`"

which did not get parsed well:

```
>>> parseaddr("Seaborne, Sam <sam.seaborne@whitehouse.gov>")
('', 'Seaborne')
```
## The Fix

This changeset addresses that by _always_ quoting the name part of the mailbox string, so we get
results like:
- `"Seaborne, Sam" <sam.seaborne@whitehouse.gov>`
- `"Jed Bartlet" <jed@whitehouse.gov>`

These do get parsed correctly by parseaddr:

```
>>> parseaddr('"Seaborne, Sam" <sam.seaborne@whitehouse.gov>')
('Seaborne, Sam', 'sam.seaborne@whitehouse.gov')
```

```
>>> parseaddr('"Jed Bartlet" <jed@whitehouse.gov>')
('Jed Bartlet', 'jed@whitehouse.gov')
```

And if no name is present, we don't feature it and just return the email address, which gets parsed fine:

```
>>> parseaddr('jed@whitehouse.gov')
('', 'jed@whitehouse.gov')
```
## Also in this PR

Broader `tox` coverage is included, which involved amending an import to allow the app to work with Django 1.9 (Issue #21)
