### PR TITLE
Add support for Mandrill's authentication.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -226,6 +226,18 @@ Configuration
     )
 
 
+Mandrill Features
+-----------------
+
+If you wish to check the X-Mandrill-Signature header that Mandrill provides
+in the requests, you will need to set the
+``INBOUND_MANDRILL_AUTHENTICATION_KEY`` setting to your Mandrill
+authentication key. When the key is supplied Inbound Email will check the
+signature supplied versus the one calculated from the request.
+
+If signatures don't match, the system will send the signal
+``email_received_unacceptable`` with the exception describing the problem.
+
 Features
 --------
 

--- a/inbound_email/errors.py
+++ b/inbound_email/errors.py
@@ -12,3 +12,8 @@ class AttachmentTooLargeError(Exception):
         self.email = email
         self.filename = filename
         self.size = size
+
+
+class AuthenticationError(Exception):
+    """Error raised when the request is not authenticated."""
+    pass

--- a/inbound_email/views.py
+++ b/inbound_email/views.py
@@ -8,7 +8,11 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods
 
 from .backends import get_backend_instance
-from .errors import RequestParseError, AttachmentTooLargeError
+from .errors import (
+    RequestParseError,
+    AttachmentTooLargeError,
+    AuthenticationError,
+)
 from .signals import email_received, email_received_unacceptable
 
 
@@ -63,6 +67,14 @@ def receive_inbound_email(request):
         email_received_unacceptable.send(
             sender=backend.__class__,
             email=ex.email,
+            request=request,
+            exception=ex
+        )
+    except AuthenticationError as ex:
+        logger.exception(ex)
+        email_received_unacceptable.send(
+            sender=backend.__class__,
+            email=None,
             request=request,
             exception=ex
         )

--- a/settings.py
+++ b/settings.py
@@ -25,6 +25,10 @@ INBOUND_EMAIL_PARSER = environ.get(
     'django_inbound_email.backends.sendgrid.SendGridRequestParser'
 )
 
+# The authentication key provided by Mandrill. If supplied, the
+# X-Mandrill-Signature header on the request will be verified during parsing.
+INBOUND_MANDRILL_AUTHENTICATION_KEY = environ.get('INBOUND_EMAIL_PARSER')
+
 # whether to dump out a log of all incoming email requests
 INBOUND_EMAIL_LOG_REQUESTS = environ.get('INBOUND_EMAIL_LOG_REQUESTS', 'false').lower() == 'true'
 


### PR DESCRIPTION
Mandrill supplies a header X-Mandrill-Signature to authenticate their
requests. This can be calculated within Inbound Email with only one
new setting to get the mandrill authentication key.

If the signatures mismatch the system should send the signal
email_received_unacceptable.

Fixes #26