### PR TITLE
Update settings.py to fix incorrect env var usage

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -27,7 +27,7 @@ INBOUND_EMAIL_PARSER = environ.get(
 
 # The authentication key provided by Mandrill. If supplied, the
 # X-Mandrill-Signature header on the request will be verified during parsing.
-INBOUND_MANDRILL_AUTHENTICATION_KEY = environ.get('INBOUND_EMAIL_PARSER')
+INBOUND_MANDRILL_AUTHENTICATION_KEY = environ.get('INBOUND_MANDRILL_AUTHENTICATION_KEY')
 
 # whether to dump out a log of all incoming email requests
 INBOUND_EMAIL_LOG_REQUESTS = environ.get('INBOUND_EMAIL_LOG_REQUESTS', 'false').lower() == 'true'


### PR DESCRIPTION
* Sets `INBOUND_MANDRILL_AUTHENTICATION_KEY` to an env var of the same name, if available, rather than incorrectly re-using the value of `INBOUND_EMAIL_PARSER`

Fixes #30 