### PR TITLE
Fix Mandrill backend silently dropping cc & bcc fields

### DIFF
--- a/inbound_email/backends/mandrill.py
+++ b/inbound_email/backends/mandrill.py
@@ -141,6 +141,8 @@ class MandrillRequestParser(RequestParser):
             try:
                 from_email = msg['from_email']
                 to = list(self._get_recipients(msg['to']))
+                cc = list(self._get_recipients(msg['cc'])) if 'cc' in msg else []
+                bcc = list(self._get_recipients(msg['bcc'])) if 'bcc' in msg else []
 
                 subject = msg.get('subject', "")
 
@@ -162,6 +164,8 @@ class MandrillRequestParser(RequestParser):
                     from_name=msg.get('from_name'),
                 ),
                 to=to,
+                cc=cc,
+                bcc=bcc,
             )
             if html is not None and len(html) > 0:
                 email.attach_alternative(html, "text/html")

--- a/inbound_email/tests/test_files/mandrill_post.py
+++ b/inbound_email/tests/test_files/mandrill_post.py
@@ -100,6 +100,18 @@ post_data_json = [
                     None
                 ]
             ],
+            "cc": [
+                [
+                    "example-cc@example.com",
+                    None
+                ]
+            ],
+            "bcc": [
+                [
+                    "example-bcc@example.com",
+                    None
+                ]
+            ],
             "from_email": "example.sender@mandrillapp.com",
             "headers": {
                 "Received": [

--- a/inbound_email/tests/test_files/mandrill_post.py
+++ b/inbound_email/tests/test_files/mandrill_post.py
@@ -128,6 +128,8 @@ post_data_json = [
                 ],
                 "Domainkey-Signature": "a=rsa-sha1; c=nofws; q=dns; s=mandrill; d=mail115.us4.mandrillapp.com; b=X6qudHd4oOJvVQZcoAEUCJgB875SwzEO5UKf6NvpfqyCVjdaO79WdDulLlfNVELeuoK2m6alt2yw 5Qhp4TW5NegyFf6Ogr/Hy0Lt411r/0lRf0nyaVkqMM/9g13B6D9CS092v70wshX8+qdyxK8fADw8 kEelbCK2cEl0AGIeAeo=;",
                 "To": "<example@example.com>",
+                "CC": "<example-cc@example.com>",
+                "BCC": "<example-bcc@example.com>",
                 "Mime-Version": "1.0",
                 "List-Unsubscribe": "<mailto:unsubscribe-md_999.aaaaaaaa.v1-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa@mailin1.us2.mcsv.net?subject=unsub>",
                 "Message-Id": "<999.20130510192820.aaaaaaaaaaaaaa.aaaaaaaa@mail115.us4.mandrillapp.com>",
@@ -238,6 +240,18 @@ post_data_json = [
                     None
                 ]
             ],
+            "cc": [
+                [
+                    "example-cc@example.com",
+                    None
+                ]
+            ],
+            "bcc": [
+                [
+                    "example-bcc@example.com",
+                    None
+                ]
+            ],
             "from_email": "example.sender@mandrillapp.com",
             "headers": {
                 "Received": [
@@ -254,6 +268,8 @@ post_data_json = [
                 ],
                 "Domainkey-Signature": "a=rsa-sha1; c=nofws; q=dns; s=mandrill; d=mail115.us4.mandrillapp.com; b=X6qudHd4oOJvVQZcoAEUCJgB875SwzEO5UKf6NvpfqyCVjdaO79WdDulLlfNVELeuoK2m6alt2yw 5Qhp4TW5NegyFf6Ogr/Hy0Lt411r/0lRf0nyaVkqMM/9g13B6D9CS092v70wshX8+qdyxK8fADw8 kEelbCK2cEl0AGIeAeo=;",
                 "To": "<example@example.com>",
+                "CC": "<example-cc@example.com>",
+                "BCC": "<example-bcc@example.com>",
                 "Mime-Version": "1.0",
                 "List-Unsubscribe": "<mailto:unsubscribe-md_999.aaaaaaaa.v1-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa@mailin1.us2.mcsv.net?subject=unsub>",
                 "Message-Id": "<999.20130510192820.aaaaaaaaaaaaaa.aaaaaaaa@mail115.us4.mandrillapp.com>",
@@ -303,6 +319,18 @@ post_data_with_attachments_json = [
                     "Hugo"
                 ]
             ],
+            "cc": [
+                [
+                    "example-cc@example.com",
+                    None
+                ]
+            ],
+            "bcc": [
+                [
+                    "example-bcc@example.com",
+                    None
+                ]
+            ],
             "email": "hugo@example.com",
             "headers": {
                 "Received": [
@@ -313,6 +341,8 @@ post_data_with_attachments_json = [
                 "From": "Vincenzo <vince@example-email.com>",
                 "X-Google-Dkim-Signature": "v=1; a=rsa-sha256; c=relaxed/relaxed; d=1e100.net; s=20130820; h=x-gm-message-state:mime-version:in-reply-to:references:date :message-id:subject:from:to:content-type; bh=8ctpVbrubLQ2/ycHWqebhhoYXGNwL4SQehME0weGkg0=; b=Q9JgnhMVivi5LHVX81C3cUV5ey4ijZtle1p73tNIEZNHJLQnHUU3bpitwD5u3svyqY 85TfKoEsmUfq0i3klSo+ECnuZFFe5/Dpz7Aq0kNalEdAXg8LFw/Su9jXiChPgro962e8 qcw8HpY0DhIcAvQOJ50lRM5mCW34IylHQG5ArUIfO9Gc+zeq7nSWAlAXZ9xVtazZnWK2 UNux6ScHmLuqm5RqHeFWKHD+yD0pDIpeRnz0jghlpwYRhM9PjogwVN6JgFxMGaIgYK+Q aeYIhvkO6Q7QO/DNmpzBw5g3MHWTpMPZJdxzUJkWdAB+w5LR2aOaDrZ4w2S3dUsYLyhx eogg==",
                 "To": "Hugo <hugo@example.com>",
+                "CC": "Example CC <example-cc@example.com>",
+                "BCC": "Example BCC <example-bcc@example.com>",
                 "X-Received": "by 10.50.137.100 with SMTP id qh4mr3649889igb.1.1431099850367; Fri, 08 May 2015 08:44:10 -0700 (PDT)",
                 "X-Gm-Message-State": "ALoCoQnKB87E+ndq9gmFG2NOzvFTV+aqYAxvb7XCIJJYN3bREJq0R5LQ7N6aow4qMDbOKcEhys03",
                 "References": "<CAEGWL=W2g0J7kK2oL5RtS3zcmxpOgTHSGOwX0VxbtDnBeaRHHQ@mail.gmail.com> <CAEGWL=VB78EjAzVEyxWkEno9rFP0jMGuEusj1+VFr54ipXtz8Q@mail.gmail.com>",

--- a/inbound_email/tests/test_mandrill.py
+++ b/inbound_email/tests/test_mandrill.py
@@ -14,19 +14,16 @@ from ..backends.mandrill import (
 )
 from ..errors import RequestParseError, AttachmentTooLargeError
 
-from .test_files.mandrill_post import post_data as mandrill_payload
 from .test_files.mandrill_post import (
-    post_data_with_attachments as mandrill_payload_with_attachments
-)
-from .test_files.mandrill_post import (
-    post_data_with_attachments_mailbox as mandrill_payload_with_attachments_mailbox
-)
-from .test_files.mandrill_post import (
-    post_data_with_attachments_mailbox_2 as mandrill_payload_with_attachments_mailbox_2
+    post_data as mandrill_payload,
+    post_data_with_attachments as mandrill_payload_with_attachments,
+    post_data_with_attachments_mailbox as mandrill_payload_with_attachments_mailbox,
+    post_data_with_attachments_mailbox_2 as mandrill_payload_with_attachments_mailbox_2,
 )
 
 
 class MandrillRequestParserTests(TestCase):
+
     def setUp(self):
         self.url = reverse('receive_inbound_email')
         self.factory = RequestFactory()
@@ -35,7 +32,7 @@ class MandrillRequestParserTests(TestCase):
         self.payload_with_attachments = mandrill_payload_with_attachments
 
     def _assertEmailParsedCorrectly(self, emails, mandrill_payload, has_html=True):
-        def _parse_to(to):
+        def _parse_emails(to):
             ret = []
             for address, name in to:
                 if not name:
@@ -52,7 +49,9 @@ class MandrillRequestParserTests(TestCase):
         for i, e in enumerate(emails):
             msg = json.loads(mandrill_payload['mandrill_events'])[i]['msg']
             self.assertEqual(e.subject, msg['subject'])
-            self.assertEqual(e.to, _parse_to(msg['to']))
+            self.assertEqual(e.to, _parse_emails(msg['to']))
+            self.assertEqual(e.cc, _parse_emails(msg['cc']))
+            self.assertEqual(e.bcc, _parse_emails(msg['bcc']))
             self.assertEqual(
                 e.from_email,
                 _parse_from(msg.get('from_name'), msg.get('from_email'))


### PR DESCRIPTION
When recreating the Django email object, the Sendgrid & Mailgun
backends implement the parsing of the cc/bcc fields of an inbound
email. However, the Mandrill one - for whatever reason - did not.

This PR fixes that.