### PR TITLE
Correct filenames for inline attachments in Mandrill

### DIFF
--- a/inbound_email/backends/mandrill.py
+++ b/inbound_email/backends/mandrill.py
@@ -77,7 +77,11 @@ class MandrillRequestParser(RequestParser):
                 content = base64.b64decode(content)
             # watchout: sometimes attachment contents are base64'd but mandrill doesn't set the flag
             elif _detect_base64(content):
-                content = base64.b64decode(content)
+                try:
+                    content = base64.b64decode(content)
+                except binascii.Error:
+                    # unable to base 64 decode. Let's just assume it is not actually base64 encoded
+                    pass
 
             content = smart_bytes(content, strings_only=True)
 

--- a/inbound_email/tests/test_mandrill.py
+++ b/inbound_email/tests/test_mandrill.py
@@ -88,7 +88,7 @@ class MandrillRequestParserTests(TestCase):
         payload = json.loads(mandrill_payload_with_attachments_mailbox['mandrill_events'])
 
         self.assertEqual(len(email.attachments), 1)
-        self.assertEqual(email.attachments[0][0], '3c8e4ffb-6366-4351-813f-d0f600ed720e')
+        self.assertEqual(email.attachments[0][0], 'Hydrofoil_en_Kitesurf.jpg')
         self.assertEqual(email.attachments[0][2], 'image/jpeg')
         self.assertEqual(
             email.attachments[0][1],
@@ -107,7 +107,7 @@ class MandrillRequestParserTests(TestCase):
         payload = json.loads(mandrill_payload_with_attachments_mailbox_2['mandrill_events'])
 
         self.assertEqual(len(email.attachments), 1)
-        self.assertEqual(email.attachments[0][0], '7e357447-3f2e-4c12-a643-5720f30ca7af')
+        self.assertEqual(email.attachments[0][0], 'Hydrofoil_en_Kitesurf.jpg')
         self.assertEqual(email.attachments[0][2], 'image/jpeg')
         self.assertEqual(
             email.attachments[0][1],


### PR DESCRIPTION
When attachments are added to an email inline, the actual filenames are not set in the mandrill `mandrill_events` JSON data. You have to look into the raw_msg to get the real filenames.

This PR returns the correct original filenames if the attachments were added inline.